### PR TITLE
Update plugin priceinsight-cn

### DIFF
--- a/stable/PriceInsightCN/manifest.toml
+++ b/stable/PriceInsightCN/manifest.toml
@@ -1,8 +1,10 @@
 [plugin]
 repository = "https://github.com/VeroFess/ffxiv-priceinsight-cn.git"
-commit = "9bfd57e621bc80d0efb242417e8aa4fe3340ac16"
+commit = "68cda34607581743a41d3c03698bdd3ff32204d8"
 owners = ["Kouzukii","VeroFess"]
 project_path = ""
 changelog = """
-- 合并上游更新并翻译
+- 切换至 HTTPS, 可以在一定程度上提升安全性
+- 切换DNS配置以实现国内外同步加速,现在在国外使用这个插件应当与原版差不多快
+- 修正查询单个物品不享受加速的问题
 """


### PR DESCRIPTION
- 切换至 HTTPS, 可以在一定程度上提升安全性
- 切换DNS配置以实现国内外同步加速,现在在国外使用这个插件应当与原版差不多快
- 修正查询单个物品不享受加速的问题