### PR TITLE
VFXEditor 1.7.9.2

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
-repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "1555f423b214eb139a78949bdb2e30fb4775e844"
+repository = "https://github.com/AtmoOmen/VFXEditor-CN.git"
+commit = "a152ca23d59f93f08da38581732d8de1564632da"
 owners = [
-    "0ceal0t",
+    "0ceal0t","AtmoOmen"
 ]
 project_path = "VFXEditor"


### PR DESCRIPTION
- 汉化
   - 汉化了界面文本、提示文本和调试信息文本
   - "Atch" 未汉化，暂时不明其具体指什么，插件也并不支持对其的验证，以后再说
   - 文本量过大，一定存在漏翻的地方，等我发现/有人上报再补
   - 存在一定的术语翻译错误的可能
   - 插件中众多 Combo 选项直接调用枚举，暂时不修改枚举
- 两个已知问题
   - 汉化后 视效(VFX) 内部分 .avfx 文件会显示解析错误 (如: 表情、过场动画)，其他 .avfx 文件解析正常
   - 但目前实际测试下来，即使显示解析错误的相关 VFX 的修改、预览、保存、导出等等功能都没有受到目前可见的实际上的影响。
   - 目前这一错误6.4首次出现，产生原因不明（先前版本如果动了和解析相关的东西，这一类型文件会全部显示解析错误且相关 VFX 的修改功能也失效）
   - 可能真的是 BUG（![image](https://github.com/ottercorp/DalamudPluginsD17/assets/110901588/f23fcfd2-4629-4f48-8915-5726aa2fff31)
   - Sklb 文件的部分编辑界面选项仍显示英文是因为作者那里没显示预设的 Name 而是拿了 Id 进行显示，暂且先不动