### PR TITLE
VFXEditorCN 1.7.9.0

### DIFF
--- a/stable/VFXEditorCN/manifest.toml
+++ b/stable/VFXEditorCN/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/VFXEditor-CN.git"
-commit = "11d96401380ad04a2c60efdc2357846d67fb993e"
+commit = "fab7739d3de7beb69b318053144168b80a726941"
 owners = [
     "0ceal0t", "AtmoOmen"
 ]

--- a/stable/VFXEditorCN/manifest.toml
+++ b/stable/VFXEditorCN/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/VFXEditor-CN.git"
-commit = "fab7739d3de7beb69b318053144168b80a726941"
+commit = "ab60ed0228944a81f6659c5ffc9019c2d568be02"
 owners = [
     "0ceal0t", "AtmoOmen"
 ]


### PR DESCRIPTION
- 回滚到 1.7.9.0
- 彻底解决了部分 .avfx 文件解析错误的问题 (Timeline 里面一个 avfxName 参数写错了)
- 新增了大约 40 条字符串翻译

技能咏唱相关avfx

![image](https://github.com/ottercorp/DalamudPluginsD17/assets/110901588/40b33fb8-5402-41a3-bf61-beb100f01a8b)

NPC相关动作avfx

![image](https://github.com/ottercorp/DalamudPluginsD17/assets/110901588/e9bf341d-61af-4a11-974f-45f6d4bdaf0c)

表情相关avfx

![image](https://github.com/ottercorp/DalamudPluginsD17/assets/110901588/8bbd7f77-d81d-456a-83d4-d70c55716693)


剩余的是之前版本就已经是解析正常状态的，所以不再列出