### PR TITLE
VFXEditorCN 1.7.9.0

### DIFF
--- a/stable/VFXEditorCN/manifest.toml
+++ b/stable/VFXEditorCN/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/VFXEditor-CN.git"
-commit = "ab60ed0228944a81f6659c5ffc9019c2d568be02"
+commit = "795a7ae258798ea6414d83069f7d4768e8fac371"
 owners = [
     "0ceal0t", "AtmoOmen"
 ]


### PR DESCRIPTION
- 新增了约 140 条字符串的翻译
   - 完成了 Atch 界面的翻译
   - 完成了 1.7.9.0 相比 1.7.5.0 新增/修改的所有字符串的翻译
   - 现在除了角落里的部分遗漏的字符串还有直接使用枚举的具体选项之外，1.7.9.0 更新字符串的翻译已经全部完成 (6.4 应该就稳定在这个版本了，不会再提交新的更新了)