### PR TITLE
VFXEditorCN 1.7.9.0

### DIFF
--- a/stable/VFXEditorCN/manifest.toml
+++ b/stable/VFXEditorCN/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/VFXEditor-CN.git"
-commit = "795a7ae258798ea6414d83069f7d4768e8fac371"
+commit = "209b7b522cc41770b7caa94c5425e959d2d86b5b"
 owners = [
     "0ceal0t", "AtmoOmen"
 ]


### PR DESCRIPTION
- 修正了一处早期翻译错误 (normal -> 法线 [原: 普通])
- 新增了约 200 条字符串翻译 (基本全是 Uld 的)