### PR TITLE
[Testing] Currency Tracker 1.3.1.1

### DIFF
--- a/testing/live/CurrencyTracker/manifest.toml
+++ b/testing/live/CurrencyTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/CurrencyTracker.git"
-commit = "e3932306a8d09f02450ca29b1bf5c852217cb256"
+commit = "f98d8ed47827fd35be6e1ba1632dcc1842a62cac"
 owners = ["AtmoOmen"]
 project_path = "CurrencyTracker"
-changelog = "- 请查阅更新日志页面"
+changelog = "- 请查阅GitHub更新日志页面"


### PR DESCRIPTION
因为之前忘写一些过滤机制了，目前国服用的 API8 最后一版 1.2.3.3 在 PVP 里的性能消耗有点超出预期的高，所以拿来目前的最新版改了一版 API8 过来

具体的更新日志：[1.2.3.3 - 1.3.1.1](https://github.com/AtmoOmen/CurrencyTracker/blob/master/Changelogs.md#%E6%9B%B4%E6%96%B0%E6%97%A5%E5%BF%97)