### PR TITLE
DeepDungeonDex 2.7.1

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/AtmoOmen/DeepDungeonDex.git"
 owners = [ "wolfcomp", "AtmoOmen" ]
 project_path = "DeepDungeonDex"
-commit = "ab55787509449dec739ccba5884b5d6ae33c674f"
+commit = "5aab3ebba33129cacae01f05238e77982e576d84"
 changelog = "### 2.7.1 (2023-09-04)\n\n\n### Bug Fixes\n\n* dont open debug window on init (50b123a)"
 version = "2.7.1"

--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
-repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
-owners = [ "wolfcomp" ]
+repository = "https://github.com/AtmoOmen/DeepDungeonDex.git"
+owners = [ "wolfcomp", "AtmoOmen" ]
 project_path = "DeepDungeonDex"
-commit = "6f3333b1369274d62ed74fa3afa844acddafb0ce"
+commit = "ab55787509449dec739ccba5884b5d6ae33c674f"
 changelog = "### 2.7.1 (2023-09-04)\n\n\n### Bug Fixes\n\n* dont open debug window on init (50b123a)"
 version = "2.7.1"


### PR DESCRIPTION
- 干掉了插件对字体的接管 (在国服运行异常)
- 修改了插件即使没有语言文件也要强行加载简繁中文+韩语导致疯狂空引用报错的奇妙逻辑