### PR TITLE
Tracky Track 1.0.0.2

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
-repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "60f76f1c1067e0a8e52cd60fabf3c49d18c8e139"
+repository = "https://github.com/AtmoOmen/TrackyTrack.git"
+commit = "5e2888ef857a8c36873b91ccc1aa186e42ec8ac6"
 owners = [
-    "Infiziert90",
+    "Infiziert90", "AtmoOmen"
 ]
 project_path = "TrackyTrack"


### PR DESCRIPTION
- 修复了分解结果追踪功能, 现在整体插件可用
- 删除了 AddonManager，用 IAddonLifecycle 替代了