### PR TITLE
DelvUI

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MeowZWR/DelvUI.git"
-commit = "056e8ab66c4dda70bc3bedfcf4705a722ce37d10"
+commit = "38a12ca38ffda1462715d037691d1a6fd92aa123"
 owners = ["Tischel","MeowZWR"]
 project_path = "DelvUI"

--- a/stable/TPie/manifest.toml
+++ b/stable/TPie/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Tischel/TPie.git"
-commit = "f0944ff7bb902701fad41873ce6e3d5aa2115bd7"
-owners = ["Tischel"]
+commit = "894d7cca9c86509346167f35a48f551ee5613f3a"
+owners = ["Tischel", "MeowZWR"]
 project_path = "TPie"
-changelog = "- Fixed various issues related to Gear Set elements."
+changelog = "- 1.8.1.0汉化。"

--- a/stable/TPie/manifest.toml
+++ b/stable/TPie/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Tischel/TPie.git"
-commit = "894d7cca9c86509346167f35a48f551ee5613f3a"
-owners = ["Tischel", "MeowZWR"]
+commit = "f0944ff7bb902701fad41873ce6e3d5aa2115bd7"
+owners = ["Tischel"]
 project_path = "TPie"
-changelog = "- 1.8.1.0汉化。"
+changelog = "- Fixed various issues related to Gear Set elements."


### PR DESCRIPTION
同步上游2.1.2.0。
老版本今天在日志中疯狂拉屎：

>  [VRB] [FONT] DelvUI plugin is initiating FONT REBUILD

更新日志：

> 添加对 Dalamund 字体“新”API 的支持。
在所有标签中新增了多行文本的支持。
可能修复了一些崩溃问题。