### PR TITLE
RemotePartyFinder 1.0.16

### DIFF
--- a/stable/RemotePartyFinder/manifest.toml
+++ b/stable/RemotePartyFinder/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
-repository = 'https://github.com/zeroeightysix/remote-party-finder.git'
-commit = '031cb81faf9a1988235784ad6f641814c7ade9e1'
-owners = [ 'zeroeightysix' ]
+repository = 'https://github.com/LittleNightmare/remote-party-finder.git'
+commit = 'fd6766fa0a9cc11e89973d9289db3a825a9b9084'
+owners = [ 'LittleNightmare' ]
 project_path = 'csharp/RemotePartyFinder'
 changelog = 'Added a new additional backend and user configuration window'


### PR DESCRIPTION
- 调整后端地址

## 🦦这个PR做了啥？
<!-- 把 [ ] 改成 [x] 勾上  -->
- [ ] ⬆️ 同步上游
- [ ] 🀄 汉化
- [x] 🛠️ 适配国服
- [ ] 🐞 修Bug（插件本身Bug请优先提交到原Repo）
- [ ] 🆕 新插件（非国服特供请优先提交到上游）

## 📃详细说明

* 添加国服后端地址，去除其他后端，findingway后端状态不明，不确定是否接收国服














<br><br><br>

> ### ✨Tips
> * 上游🐐[GoatCorp](https://github.com/goatcorp/DalamudPluginsD17)
> * 回复 `@aonyxbot rebuild` 来触发 Build
> * 有问题？找Review？进泛獭频道看看吧!
> [【艾欧泽亚泛獭保护协会】](https://pd.qq.com/s/adka09q6e)
